### PR TITLE
fix header menu

### DIFF
--- a/src/components/widgets/Header/Header.tsx
+++ b/src/components/widgets/Header/Header.tsx
@@ -47,7 +47,7 @@ const Header: React.FC = () => {
               {t('allShop')}
             </CategoriesButton>
             <Nav
-              menuId={344}
+              menuId={19521}
               skeleton={{
                 elements: 3,
                 width: '80px',


### PR DESCRIPTION
A new menu has been added for the header, while the old menu is used in the footer in WordPress. Everything has been added to it except for "Sale" since such a category does not exist on the website.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209365335672290