### PR TITLE
add logic to viewing count

### DIFF
--- a/src/components/pages/product/ProductInfo/ProductInfo.tsx
+++ b/src/components/pages/product/ProductInfo/ProductInfo.tsx
@@ -75,6 +75,7 @@ const ProductInfo: React.FC<ProductCardPropsType> = ({ product }) => {
 
   const [quantity, setQuantity] = useState<number>(1);
   const [cartMatch, setCartMatch] = useState<CartItem>();
+  const [viewing, setViewing] = useState<number>(0);
 
   /**
    * Choosen variation
@@ -173,6 +174,22 @@ const ProductInfo: React.FC<ProductCardPropsType> = ({ product }) => {
         ]
       : [...images];
 
+  useEffect(() => {
+    if (stockQuantity === 0) {
+      setViewing(1);
+    } else if (stockQuantity < 10) {
+      const maxReduction = stockQuantity * 0.2;
+      const randomReduction = Math.ceil(Math.random() * maxReduction);
+      const finalValue = Math.max(1, stockQuantity - randomReduction);
+      setViewing(finalValue);
+    } else {
+      const randomValue = Math.random();
+      const adjustedValue = Math.pow(randomValue, 0.5);
+      const finalValue = Math.max(1, Math.floor(adjustedValue * 10));
+      setViewing(finalValue);
+    }
+  }, [stockQuantity]);
+
   return (
     <ProductWrapper>
       <ProductImageWrapper>
@@ -193,7 +210,7 @@ const ProductInfo: React.FC<ProductCardPropsType> = ({ product }) => {
         </Title>
         <ProductFlexWrapper>
           <ProductAvailable count={stockQuantity} />
-          <ProductViewing count={stockQuantity} />
+          <ProductViewing count={viewing} />
         </ProductFlexWrapper>
         <ProductFlexWrapper>
           {currentVariation?.sku ||


### PR DESCRIPTION
**Description**
This feature adds a dynamic viewing count to product pages based on the stock quantity. The logic is as follows:
    When the stock quantity is 0:
        The viewing count is set to 1, simulating a single viewer (as the product is out of stock).
    When the stock quantity is less than 10:
        The viewing count is adjusted to be close to the available stock quantity but slightly reduced to create a sense of urgency. A random reduction is calculated based on 20% of the stock quantity, and the final viewing count is shown. The count is ensured to be at least 1.
    When the stock quantity is 10 or more:
        A random viewing count between 1 and 10 is shown. The number is adjusted using a square root function to skew the distribution toward larger numbers, making it more likely for higher values to appear.

**Type of change**
- [x] Feature

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209595625555909