### PR TITLE
Dev

### DIFF
--- a/src/pages/product/[slug].tsx
+++ b/src/pages/product/[slug].tsx
@@ -55,7 +55,21 @@ export default function ProductPage({
   const t = useTranslations('Product');
 
   useEffect(() => {
-    const categoriesWithLang = product.categories.map(item => ({
+    const categories = product.categories;
+
+    const childCategory =
+      categories.find(cat => cat.parent_id !== 0 && cat.is_hidden === false) ||
+      categories[0];
+
+    const parentCategory = categories.find(
+      cat => cat.id === childCategory.parent_id
+    );
+
+    const selectedCategories = parentCategory
+      ? [parentCategory, childCategory]
+      : [childCategory];
+
+    const categoriesWithLang = selectedCategories.map(item => ({
       ...item,
       language_code: locale,
     }));
@@ -101,6 +115,8 @@ export default function ProductPage({
   }
 
   const products: ProductType[] = filteredRecommendedProducts || [];
+
+  console.log('product...', product);
 
   return (
     <>

--- a/src/pages/product/[slug].tsx
+++ b/src/pages/product/[slug].tsx
@@ -116,8 +116,6 @@ export default function ProductPage({
 
   const products: ProductType[] = filteredRecommendedProducts || [];
 
-  console.log('product...', product);
-
   return (
     <>
       <Head>

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -174,7 +174,7 @@
     "view": "Вид",
     "giftcertificate": "Подарочный сертификат",
     "mattresscover": "Чехол на матрас",
-    "twist": "Подкрутка",
+    "twist": "Изгиб",
     "volume": "Объем"
   },
   "Product": {
@@ -224,7 +224,7 @@
     "length": "Длина",
     "size": "Размер",
     "thickness": "Толщина",
-    "twist": "Подкрутка",
+    "twist": "Изгиб",
     "view": "Вид",
     "volume": "Объем",
     "volumes": "Объемы",

--- a/src/translations/uk.json
+++ b/src/translations/uk.json
@@ -174,7 +174,7 @@
     "view": "Вид",
     "giftcertificate": "Подарунковий сертифікат",
     "mattresscover": "Чехол на матрац",
-    "twist": "Підкручення",
+    "twist": "Вигин",
     "volume": "Об'єм"
   },
   "Product": {
@@ -224,7 +224,7 @@
     "length": "Довжина",
     "size": "Розмір",
     "thickness": "Товщина",
-    "twist": "Підкручення",
+    "twist": "Вигин",
     "view": "Вид",
     "volume": "Об'єм",
     "volumes": "Об'єми",

--- a/src/types/components/shop/product/products.ts
+++ b/src/types/components/shop/product/products.ts
@@ -6,6 +6,7 @@ export const ProductCategorySchema = z.object({
   name: z.string(),
   slug: z.string(),
   description: z.string(),
+  is_hidden: z.boolean().optional(),
   count: z.number(),
   menu_order: z.number().optional(),
 });


### PR DESCRIPTION
**Description**
Added logic to generate breadcrumbs on the product page using only the visible child category and its parent. The transformCategoriesIntoLinks function is now used with a filtered subset of categories rather than the full list.
Selected the first visible child category (is_hidden === false) and its parent from the product's categories.

**Type of change**
- [x] Feature