### PR TITLE
add canonical url

### DIFF
--- a/src/components/shop/Archive/Archive.tsx
+++ b/src/components/shop/Archive/Archive.tsx
@@ -1,10 +1,17 @@
 import { CustomSortAccordion } from '@/components/global/accordions/CustomSortAccordion';
 import Breadcrumbs from '@/components/global/Breadcrumbs/Breadcrumbs';
+import {
+  BreadcrumbLink,
+  BreadcrumbsList,
+  BreadcrumbsWrapper,
+} from '@/components/global/Breadcrumbs/styles';
 import FilterButton from '@/components/global/buttons/FilterButton/FilterButton';
 import CloseIcon from '@/components/global/icons/CloseIcon/CloseIcon';
 import Notification from '@/components/global/Notification/Notification';
 import MobileCategoriesMenu from '@/components/global/popups/MobileCategoriesMenu/MobileCategoriesMenu';
+import { PageTitle } from '@/components/pages/pageTitle';
 import CategoriesMenu from '@/components/shop/categories/CategoriesMenu/CategoriesMenu';
+import { useCanonicalUrl } from '@/hooks/useCanonicalUrl';
 import { useResponsive } from '@/hooks/useResponsive';
 import transformCategoriesIntoLinks from '@/services/transformers/transformCategoriesIntoLinks';
 import { useAppSelector } from '@/store';
@@ -14,6 +21,7 @@ import { CategoryType } from '@/types/pages/shop';
 import { getPluralForm } from '@/utils/getPluralForm';
 import { Skeleton } from '@mui/material';
 import { useTranslations } from 'next-intl';
+import Head from 'next/head';
 import router from 'next/router';
 import { FC, useState } from 'react';
 import SelectParentCategory from '../categories/SelectParentCategoryMobile/SelectParentCategoryMobile';
@@ -35,12 +43,6 @@ import {
   PagesNavigationFooterWrapper,
   PagesNavigationWrapper,
 } from './styles';
-import {
-  BreadcrumbLink,
-  BreadcrumbsList,
-  BreadcrumbsWrapper,
-} from '@/components/global/Breadcrumbs/styles';
-import { PageTitle } from '@/components/pages/pageTitle';
 
 const switchPage = (page: number, maxPage: number) => {
   if (maxPage < page) return;
@@ -89,6 +91,7 @@ export const Archive: FC<ArchivePropsType> = props => {
     defaultLocale,
   } = props;
   const t = useTranslations('Archive');
+  const canonicalUrl = useCanonicalUrl();
 
   const currentCategory = Array.isArray(categories)
     ? (categories[categories.length - 1] as CategoryType)
@@ -158,6 +161,9 @@ export const Archive: FC<ArchivePropsType> = props => {
 
   return (
     <>
+      <Head>
+        <link rel="canonical" href={canonicalUrl} />
+      </Head>
       <PageTitle
         title={currentCategory?.name || `${t('phraseSought')}: "${searchTerm}"`}
       />

--- a/src/hooks/useCanonicalUrl.ts
+++ b/src/hooks/useCanonicalUrl.ts
@@ -1,0 +1,18 @@
+import { useRouter } from 'next/router';
+
+export const useCanonicalUrl = () => {
+    const router = useRouter();
+
+    if (typeof window === 'undefined') return '';
+
+    const origin = window.location.origin;
+
+    const localePrefix =
+        router.locale && router.locale !== router.defaultLocale
+            ? `/${router.locale}`
+            : '';
+
+    const pathWithoutQuery = router.asPath.split('?')[0];
+
+    return `${origin}${localePrefix}${pathWithoutQuery}`;
+};

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -17,18 +17,20 @@ import { BlogPostContent } from '@/components/pages/blog/blogPostContent';
 import { BlogTitle } from '@/components/pages/blog/blogTitle';
 import { PostGroupNavigationButton } from '@/components/pages/blog/postGroupNavigationButton';
 import { PostPageBreadcrumbs } from '@/components/pages/blog/postPageBreadcrumbs';
+import BlogInfo from '@/components/pages/main/BlogListBlock/BlogInfo/BlogInfo';
 import {
   CategoriesTagWrapper,
   StyledTag,
 } from '@/components/pages/main/BlogListBlock/BlogItem/styles';
 import BlogListBlock from '@/components/pages/main/BlogListBlock/BlogListBlock';
+import { PageTitle } from '@/components/pages/pageTitle';
+import { useCanonicalUrl } from '@/hooks/useCanonicalUrl';
 import {
   StyledBox,
   StyledContainer,
   StyledHeroImage,
 } from '@/styles/blog/styles';
-import BlogInfo from '@/components/pages/main/BlogListBlock/BlogInfo/BlogInfo';
-import { PageTitle } from '@/components/pages/pageTitle';
+import Head from 'next/head';
 
 export const getServerSideProps: GetServerSideProps = async (
   context: GetServerSidePropsContext
@@ -133,6 +135,8 @@ interface PageProps {
 }
 
 const BlogPostPage = ({ post, recommendedPosts, popularPosts }: PageProps) => {
+  const canonicalUrl = useCanonicalUrl();
+
   if (!post) {
     return <StyledError>No Post found</StyledError>;
   }
@@ -160,6 +164,9 @@ const BlogPostPage = ({ post, recommendedPosts, popularPosts }: PageProps) => {
 
   return (
     <>
+      <Head>
+        <link rel="canonical" href={canonicalUrl} />
+      </Head>
       <PageTitle title={title} />
       <SectionContainer>
         <StyledContainer>

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -8,6 +8,7 @@ import {
   RecommendContainer,
   SectionContainer,
 } from '@/components/sections/styles';
+import { useCanonicalUrl } from '@/hooks/useCanonicalUrl';
 import { customRestApi } from '@/services/wpCustomApi';
 import { Container, StyledHeaderWrapper } from '@/styles/components';
 import { BlogCategoryType, BlogParsedItemType } from '@/types/pages/blog';
@@ -16,6 +17,7 @@ import { serverParseHTMLContent } from '@/utils/blog/serverParseHTMLContent';
 import { validateWpBlogPage } from '@/utils/zodValidators/validateWpBlogPage';
 import { omit } from 'lodash';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 
 export const getServerSideProps: GetServerSideProps = async (
@@ -115,6 +117,8 @@ const BlogPage: React.FC<BlogProps> = ({
 }) => {
   const router = useRouter();
 
+  const canonicalUrl = useCanonicalUrl();
+
   const handleCategoryChange = (categorySlug: string | null) => {
     let newQuery = categorySlug
       ? { ...router.query, category: categorySlug }
@@ -130,6 +134,9 @@ const BlogPage: React.FC<BlogProps> = ({
 
   return (
     <>
+      <Head>
+        <link rel="canonical" href={canonicalUrl} />
+      </Head>
       <PageTitle nameSpace={'Breadcrumbs'} spaceKey={'blogPage'} />
       <Container>
         <StyledHeaderWrapper>

--- a/src/pages/product/[slug].tsx
+++ b/src/pages/product/[slug].tsx
@@ -149,8 +149,6 @@ export default function ProductPage({
   const productUrl = fullUrl;
   const canonicalUrl = useCanonicalUrl();
 
-  console.log('canonicalUrl...', canonicalUrl);
-
   const schemaProduct = {
     '@context': 'https://schema.org/',
     '@type': 'Product',

--- a/src/pages/product/[slug].tsx
+++ b/src/pages/product/[slug].tsx
@@ -8,6 +8,7 @@ import {
   TitleBlock,
 } from '@/components/sections/styles';
 import { ProductCardList } from '@/components/shop/ProductCardsList';
+import { useCanonicalUrl } from '@/hooks/useCanonicalUrl';
 import transformCategoriesIntoLinks from '@/services/transformers/transformCategoriesIntoLinks';
 import { customRestApi } from '@/services/wpCustomApi';
 import { useGetProductsQuery } from '@/store/rtk-queries/wpCustomApi';
@@ -146,6 +147,9 @@ export default function ProductPage({
   const productImage =
     product?.seo_data?.images?.[0]?.['image:loc'] || product?.images?.[0]?.src;
   const productUrl = fullUrl;
+  const canonicalUrl = useCanonicalUrl();
+
+  console.log('canonicalUrl...', canonicalUrl);
 
   const schemaProduct = {
     '@context': 'https://schema.org/',
@@ -181,7 +185,7 @@ export default function ProductPage({
         <meta property="og:image" content={productImage} />
         <meta property="og:type" content="product" />
         <meta property="og:url" content={productUrl} />
-        <link rel="canonical" href={productUrl} />
+        <link rel="canonical" href={canonicalUrl} />
         {
           <script type="application/ld+json">
             {JSON.stringify(schemaProduct)}


### PR DESCRIPTION
**Description**
This PR adds canonical URLs for the following pages to improve SEO:
    Blog listing page (/blog)
    Blog post pages (/blog/[slug])
    Product pages (/product/[slug])
    Product category pages (/product-category/[slug])
The canonical URLs exclude query parameters and consider the current language.
A custom hook was created to handle the generation of the canonical URL.

**Type of change**
- [x] Feature (adds canonical URL tags for SEO)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210194551348427